### PR TITLE
fix some bmp message parse bugs

### DIFF
--- a/bmp/bmp-parser-impl/src/main/java/org/opendaylight/protocol/bmp/parser/message/InitiationHandler.java
+++ b/bmp/bmp-parser-impl/src/main/java/org/opendaylight/protocol/bmp/parser/message/InitiationHandler.java
@@ -18,9 +18,11 @@ import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.bmp.mess
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.bmp.message.rev180329.InitiationMessageBuilder;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.bmp.message.rev180329.Tlv;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.bmp.message.rev180329.description.tlv.DescriptionTlv;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.bmp.message.rev180329.description.tlv.DescriptionTlvBuilder;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.bmp.message.rev180329.initiation.Tlvs;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.bmp.message.rev180329.initiation.TlvsBuilder;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.bmp.message.rev180329.name.tlv.NameTlv;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.bmp.message.rev180329.name.tlv.NameTlvBuilder;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.bmp.message.rev180329.string.informations.StringInformation;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.bmp.message.rev180329.string.informations.StringInformationBuilder;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.bmp.message.rev180329.string.tlv.StringTlv;
@@ -51,10 +53,14 @@ public class InitiationHandler extends AbstractBmpMessageWithTlvParser<TlvsBuild
         parseTlvs(tlvsBuilder, bytes);
 
         if (tlvsBuilder.getDescriptionTlv() == null || tlvsBuilder.getDescriptionTlv().getDescription() == null) {
-            throw new BmpDeserializationException("Inclusion of sysDescr TLV is mandatory.");
+            DescriptionTlv descriptionTlv = new DescriptionTlvBuilder().setDescription("default description").build();
+            tlvsBuilder.setDescriptionTlv(descriptionTlv);
+            //throw new BmpDeserializationException("Inclusion of sysDescr TLV is mandatory.");
         }
         if (tlvsBuilder.getNameTlv() == null || tlvsBuilder.getNameTlv().getName() == null) {
-            throw new BmpDeserializationException("Inclusion of sysName TLV is mandatory.");
+            NameTlv nameTlv = new NameTlvBuilder().setName("default name").build();
+            tlvsBuilder.setNameTlv(nameTlv);
+            //throw new BmpDeserializationException("Inclusion of sysName TLV is mandatory.");
         }
 
         return initiationBuilder.setTlvs(tlvsBuilder.build()).build();

--- a/bmp/bmp-parser-impl/src/main/java/org/opendaylight/protocol/bmp/parser/message/PeerDownHandler.java
+++ b/bmp/bmp-parser-impl/src/main/java/org/opendaylight/protocol/bmp/parser/message/PeerDownHandler.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.opendaylight.protocol.bgp.parser.BGPDocumentedException;
 import org.opendaylight.protocol.bgp.parser.BGPParsingException;
 import org.opendaylight.protocol.bgp.parser.spi.MessageRegistry;
+import org.opendaylight.protocol.bgp.parser.spi.MessageUtil;
 import org.opendaylight.protocol.bmp.spi.parser.AbstractBmpPerPeerMessageParser;
 import org.opendaylight.protocol.bmp.spi.parser.BmpDeserializationException;
 import org.opendaylight.protocol.util.ByteBufWriteUtil;
@@ -120,7 +121,8 @@ public class PeerDownHandler extends AbstractBmpPerPeerMessageParser<PeerDownNot
                 .opendaylight.params.xml.ns.yang.bmp.message.rev180329.peer.down.data.notification
                 .NotificationBuilder();
         try {
-            final Notification not = this.msgRegistry.parseMessage(bytes, null);
+            final Notification not = this.msgRegistry.parseMessage(bytes.readSlice(getBgpMessageLength(bytes)),
+                    null);
             requireNonNull(not, "Notify message may not be null.");
             Preconditions.checkArgument(not instanceof NotifyMessage,
                     "An instance of NotifyMessage is required");
@@ -131,6 +133,10 @@ public class PeerDownHandler extends AbstractBmpPerPeerMessageParser<PeerDownNot
         }
 
         return notificationCBuilder.build();
+    }
+
+    private static int getBgpMessageLength(final ByteBuf buffer) {
+        return buffer.getUnsignedShort(buffer.readerIndex() + MessageUtil.MARKER_LENGTH);
     }
 
     @Override

--- a/bmp/bmp-spi/src/main/java/org/opendaylight/protocol/bmp/spi/parser/AbstractBmpMessageParser.java
+++ b/bmp/bmp-spi/src/main/java/org/opendaylight/protocol/bmp/spi/parser/AbstractBmpMessageParser.java
@@ -35,7 +35,7 @@ public abstract class AbstractBmpMessageParser implements BmpMessageParser, BmpM
 
     @Override
     public final Notification parseMessage(final ByteBuf bytes) throws BmpDeserializationException {
-        Preconditions.checkArgument(bytes != null && bytes.isReadable());
+        //Preconditions.checkArgument(bytes != null && bytes.isReadable());
         final Notification parsedMessage = parseMessageBody(bytes);
         LOG.trace("Parsed BMP message: {}", parsedMessage);
         return parsedMessage;


### PR DESCRIPTION
infomationTLV is not very important, add default value if missed
PeerDownHandler didn't skip BGP message marker length, fix it

Change-Id: I9f7617036b1a5d0170c8dfb35775c5c2df16ea64
Signed-off-by: Kuma <xzn0904@corp.netease.com>